### PR TITLE
Add interactive lineage grid UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t
+# Programming Lineage Grid
+
+This repo contains a small, self-contained web page that renders an interactive
+lineage grid. Paste your full A–Z lineage list, click **Load grid**, then tap any
+card to explore the chain with clickable nodes.
+
+## Usage
+
+1. Open `index.html` in a browser (or run a local server).
+2. Paste your lineage list in the textarea (one lineage per line).
+3. Click **Load grid** to render the interactive layout.
+
+### Optional local server
+
+```sh
+python -m http.server 8080
+```
+
+Then open <http://localhost:8080>.
+
+## Lineage format
+
+```
+Language = Descendant → Descendant → Descendant
+```
+
+You can paste the entire 215-root/900-derivative list and the grid will index it
+with search + letter filters.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,182 @@
+const SAMPLE_LINEAGES = [
+  "Ada = SPARK → VHDL → Eiffel → GNAT → Ravenscar",
+  "C = C++ → Objective-C → C# → D → Rust → Zig → Go → V → Nim",
+  "JavaScript = TypeScript → JSX → ReScript → Elm → Svelte → Astro",
+  "Python = Ruby → Julia → Mojo → Coconut → PyPy → MicroPython → RustPython",
+  "Rust = Zig → V → Odin → Carbon → Mojo → Vale",
+];
+
+const sourceInput = document.getElementById("sourceInput");
+const loadButton = document.getElementById("loadButton");
+const resetButton = document.getElementById("resetButton");
+const searchInput = document.getElementById("searchInput");
+const grid = document.getElementById("grid");
+const details = document.getElementById("details");
+const letterFilters = document.getElementById("letterFilters");
+
+let lineages = [];
+let activeLetter = "all";
+let activeIndex = null;
+let searchTerm = "";
+
+function normalizeLine(line) {
+  return line
+    .replace(/^[\s\u2705\u26a1\u2728\u2728\u1f4a0\u1f5a4]+/u, "")
+    .trim();
+}
+
+function parseLineages(rawText) {
+  return rawText
+    .split("\n")
+    .map((line) => normalizeLine(line))
+    .filter((line) => line.includes("="))
+    .map((line) => {
+      const [root, rest] = line.split("=").map((part) => part.trim());
+      const chain = rest
+        ? rest.split("→").map((part) => part.trim()).filter(Boolean)
+        : [];
+      return {
+        root,
+        chain,
+        full: `${root} = ${chain.join(" → ")}`,
+      };
+    });
+}
+
+function buildLetterFilters() {
+  const letters = ["all", ..."ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("")];
+  letterFilters.innerHTML = "";
+
+  letters.forEach((letter) => {
+    const chip = document.createElement("button");
+    chip.className = "filter-chip";
+    chip.type = "button";
+    chip.textContent = letter.toUpperCase();
+    chip.dataset.letter = letter;
+    chip.addEventListener("click", () => {
+      activeLetter = letter;
+      render();
+    });
+    letterFilters.appendChild(chip);
+  });
+}
+
+function updateFilterState() {
+  [...letterFilters.children].forEach((chip) => {
+    chip.classList.toggle(
+      "is-active",
+      chip.dataset.letter === activeLetter
+    );
+  });
+}
+
+function filterLineages() {
+  return lineages.filter((lineage) => {
+    const matchesLetter =
+      activeLetter === "all" ||
+      lineage.root.toLowerCase().startsWith(activeLetter);
+    const matchesSearch = lineage.full
+      .toLowerCase()
+      .includes(searchTerm);
+    return matchesLetter && matchesSearch;
+  });
+}
+
+function renderGrid(items) {
+  grid.innerHTML = "";
+  if (items.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "empty";
+    empty.textContent = "No lineages match your filters.";
+    grid.appendChild(empty);
+    return;
+  }
+
+  items.forEach((lineage, index) => {
+    const tile = document.createElement("button");
+    tile.type = "button";
+    tile.className = "tile";
+    tile.innerHTML = `
+      <div class="tile__title">${lineage.root}</div>
+      <div class="tile__count">${lineage.chain.length} descendants</div>
+      <div class="tile__preview">${lineage.chain.slice(0, 3).join(" → ")}${
+        lineage.chain.length > 3 ? " …" : ""
+      }</div>
+    `;
+    tile.addEventListener("click", () => {
+      activeIndex = index;
+      renderDetails(lineage);
+    });
+    grid.appendChild(tile);
+  });
+}
+
+function renderDetails(lineage) {
+  details.innerHTML = `
+    <h2 class="details__title">${lineage.root}</h2>
+    <p class="details__text">${lineage.chain.length} descendants</p>
+    <div class="chain"></div>
+  `;
+
+  const chain = details.querySelector(".chain");
+  const nodes = [lineage.root, ...lineage.chain];
+  nodes.forEach((node, index) => {
+    const tag = document.createElement("button");
+    tag.type = "button";
+    tag.className = "chain__node";
+    tag.textContent = node;
+    tag.addEventListener("click", () => {
+      [...chain.children].forEach((child) =>
+        child.classList.remove("is-active")
+      );
+      tag.classList.add("is-active");
+    });
+    if (index === 0) {
+      tag.classList.add("is-active");
+    }
+    chain.appendChild(tag);
+  });
+}
+
+function render() {
+  updateFilterState();
+  const filtered = filterLineages();
+  renderGrid(filtered);
+}
+
+function loadFromInput() {
+  const raw = sourceInput.value.trim();
+  lineages = raw ? parseLineages(raw) : [...SAMPLE_LINEAGES].map((line) => {
+    const [root, rest] = line.split("=").map((part) => part.trim());
+    const chain = rest.split("→").map((part) => part.trim());
+    return { root, chain, full: `${root} = ${chain.join(" → ")}` };
+  });
+  activeIndex = null;
+  render();
+}
+
+function resetAll() {
+  sourceInput.value = SAMPLE_LINEAGES.join("\n");
+  searchInput.value = "";
+  searchTerm = "";
+  activeLetter = "all";
+  activeIndex = null;
+  loadFromInput();
+  details.innerHTML = `
+    <h2 class="details__title">Select a lineage</h2>
+    <p class="details__text">
+      Click any tile to preview the full chain with clickable nodes.
+    </p>
+  `;
+}
+
+searchInput.addEventListener("input", (event) => {
+  searchTerm = event.target.value.trim().toLowerCase();
+  render();
+});
+
+loadButton.addEventListener("click", loadFromInput);
+resetButton.addEventListener("click", resetAll);
+
+buildLetterFilters();
+resetAll();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lineage Grid</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="page">
+      <header class="header">
+        <div>
+          <h1>Programming Lineage Grid</h1>
+          <p>
+            Paste your A–Z lineage list, then click any entry to see the full
+            chain. Use search and letter filters to narrow the grid.
+          </p>
+        </div>
+        <div class="header__actions">
+          <button id="resetButton" class="button button--ghost">Reset</button>
+        </div>
+      </header>
+
+      <section class="panel">
+        <label class="label" for="sourceInput">Lineage source (one per line)</label>
+        <textarea
+          id="sourceInput"
+          class="textarea"
+          rows="8"
+          spellcheck="false"
+        ></textarea>
+        <div class="panel__actions">
+          <button id="loadButton" class="button">Load grid</button>
+          <span class="hint"
+            >Format: <code>Language = Descendant → Descendant → ...</code></span
+          >
+        </div>
+      </section>
+
+      <section class="toolbar">
+        <input
+          id="searchInput"
+          class="input"
+          type="search"
+          placeholder="Search lineages"
+          aria-label="Search lineages"
+        />
+        <div id="letterFilters" class="filters" aria-label="Filter by letter"></div>
+      </section>
+
+      <section class="grid" id="grid" aria-live="polite"></section>
+
+      <section class="details" id="details">
+        <h2 class="details__title">Select a lineage</h2>
+        <p class="details__text">
+          Click any tile to preview the full chain with clickable nodes.
+        </p>
+      </section>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,215 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: #f5f7fb;
+  color: #0f172a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 32px 24px 64px;
+  display: grid;
+  gap: 24px;
+}
+
+.header {
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.header h1 {
+  margin: 0 0 8px;
+  font-size: 2rem;
+}
+
+.header p {
+  margin: 0;
+  max-width: 700px;
+  color: #475569;
+}
+
+.header__actions {
+  display: flex;
+  gap: 12px;
+}
+
+.panel {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 12px;
+}
+
+.label {
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.textarea {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+  padding: 12px;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.9rem;
+  background: #f8fafc;
+}
+
+.panel__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.hint {
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.button {
+  border: none;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  background: #2563eb;
+  color: white;
+  cursor: pointer;
+}
+
+.button--ghost {
+  background: #e2e8f0;
+  color: #1e293b;
+}
+
+.button:hover {
+  filter: brightness(0.95);
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.input {
+  flex: 1 1 260px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid #cbd5f5;
+  background: #ffffff;
+}
+
+.filters {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.filter-chip {
+  border-radius: 999px;
+  padding: 6px 12px;
+  border: 1px solid #cbd5f5;
+  background: #fff;
+  color: #334155;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.filter-chip.is-active {
+  background: #1d4ed8;
+  color: #fff;
+  border-color: #1d4ed8;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.tile {
+  border-radius: 14px;
+  background: #fff;
+  padding: 16px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+  display: grid;
+  gap: 8px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tile:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+}
+
+.tile__title {
+  font-weight: 700;
+}
+
+.tile__count {
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.details {
+  background: #0f172a;
+  color: #f8fafc;
+  border-radius: 18px;
+  padding: 24px;
+  min-height: 140px;
+}
+
+.details__title {
+  margin: 0 0 8px;
+}
+
+.details__text {
+  margin: 0;
+  color: #cbd5f5;
+}
+
+.chain {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.chain__node {
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.chain__node.is-active {
+  background: #38bdf8;
+  border-color: #38bdf8;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.empty {
+  text-align: center;
+  color: #94a3b8;
+  padding: 40px 0;
+}


### PR DESCRIPTION
### Motivation
- Provide an interactive, browser-based way to load and explore the A–Z programming lineage list so users can click into chains, search, and filter by letter.

### Description
- Add `index.html` which implements the UI scaffold with a textarea, load/reset controls, search input, letter filter chips, a grid of tiles, and a details panel.
- Add `app.js` which parses lines in the form `Language = Descendant → Descendant`, indexes the data, builds letter filters, renders filterable tiles, and displays clickable chain nodes with sample data and reset behavior.
- Add `styles.css` to style the page, controls, tiles, and detail panel for a clean responsive grid layout.
- Update `README.md` to document usage, the expected lineage format, and an optional local server command.

### Testing
- Served the site locally with `python -m http.server` and verified the files were served successfully.
- Ran a headless Playwright script to load `index.html` and capture a screenshot (`artifacts/lineage-grid.png`), which completed successfully.
- No unit or integration test suite was added as this change is static frontend content only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cd86c23a48325b787c5a6809b6daa)